### PR TITLE
do not cancel all builds on failure

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,6 +8,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-18.04, macos-latest]
         python-version: [3.6, 3.7, 3.8]

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -4,8 +4,7 @@ name: Test Python package
 on: [push, pull_request]
 
 jobs:
-  build:
-
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -35,3 +34,18 @@ jobs:
         run: make check
       - name: Make package
         run: make dist
+  tagging:
+    needs: [test]
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Bump version and push tag
+      uses: maxbachmann/rhasspy-tag-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      id: bump_tag
+    - name: print tag
+      if: steps.bump_tag.outputs.new_tag
+      run: |
+        echo steps.bump_tag.outputs.new_tag

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -45,7 +45,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: bump_tag
-      - name: print tag
-        if: steps.bump_tag.outputs.new_tag
-        run: |
-          echo steps.bump_tag.outputs.new_tag

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -39,13 +39,13 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Bump version and push tag
-      uses: maxbachmann/rhasspy-tag-action@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      id: bump_tag
-    - name: print tag
-      if: steps.bump_tag.outputs.new_tag
-      run: |
-        echo steps.bump_tag.outputs.new_tag
+      - uses: actions/checkout@master
+      - name: Bump version and push tag
+        uses: maxbachmann/rhasspy-tag-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: bump_tag
+      - name: print tag
+        if: steps.bump_tag.outputs.new_tag
+        run: |
+          echo steps.bump_tag.outputs.new_tag


### PR DESCRIPTION
by default github actions will cancel the whole build matrix the moment one of the builds fails. This turns this off, so we can still see the results for different platforms

adds action to automatically add lightweight tags on the master branch when the version in VERSION is incremented